### PR TITLE
Added function to stop tracking config items.

### DIFF
--- a/govcms_tools/govcms_tools.module
+++ b/govcms_tools/govcms_tools.module
@@ -137,3 +137,38 @@ function govcms_tools_delete_menu_item($path, $menu_name) {
     menu_link_delete($value->mlid);
   }
 }
+
+/**
+ * Stop tracking configuration items.
+ *
+ * @param array $items
+ *  Items to stop tracking.
+ */
+function govcms_tools_config_stop_tracking(array $items) {
+  if (class_exists('Drupal\configuration\Utils\ConfigIteratorSettings')) {
+    $config_settings = new Drupal\configuration\Utils\ConfigIteratorSettings(
+      array(
+        'build_callback' => 'loadFromStorage',
+        'callback' => 'import',
+        'process_dependencies' => FALSE,
+        'process_optionals' => FALSE,
+        'settings' => array(
+          'source' => NULL,
+        ),
+        'info' => array(
+          'imported' => array(),
+          'fail' => array(),
+          'no_handler' => array(),
+        )
+      )
+    );
+
+    $instance_method = array('Drupal\configuration\Config\ConfigurationManagement', 'createConfigurationInstance');
+    if (is_callable($instance_method)) {
+      foreach ($items as $item) {
+        $config_instance = Drupal\configuration\Config\ConfigurationManagement::createConfigurationInstance($item);
+        $config_instance->stopTracking($config_settings);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This one uses a different method to the one we used before, which took a really long time to finish and didn't actually work on Acquia environments when the config directory is read-only. This one just removes the database record for the tracked item.

TODO: Add a similar function to start tracking config items. The only change would be to (theoretically) just use `$config_instance->startTracking` instead.
